### PR TITLE
Added support for remote images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-remark-eleventy-image",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-remark-eleventy-image",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-img": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-remark-eleventy-image",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Remark plugin for Astro that automatically optimizes images referenced in markdown files.",
   "author": "ChrisOh431",
   "license": "MIT",

--- a/src/astro-remark-images.ts
+++ b/src/astro-remark-images.ts
@@ -64,13 +64,6 @@ function remarkEleventyImage()
             const visitor = (node: any) =>
             {
                 /*
-                    Don't mess with external images.
-                    There's probably a more elegant method to detect these
-                    that I can't recall at the time.
-                */
-                if (node.url.indexOf("http") == 0) return;
-
-                /*
                     Use alt text. Accessibility is good! :)
                 */
                 if (!node.alt)
@@ -89,12 +82,27 @@ function remarkEleventyImage()
             {
                 let originalImagePath;
                 let outputImageDir;
+                let outputImageDirHTML;
 
                 try
                 {
                     console.log(`(astro-remark-images) Optimizing image: ${path.basename(node.url)} referenced in file: ${path.basename(file.path)}`);
-                    originalImagePath = path.join(publicDir, node.url);
-                    outputImageDir = path.dirname(path.join(outDir, node.url));
+                    if (node.url.indexOf("http") == 0) 
+                    {
+                        // Remote image. In this case the optimized images are put
+                        // in a subdirectory of '/arei-optimg/' based on the markdown file name.
+                        originalImagePath = node.url;
+                        outputImageDir = path.join(outDir, '/arei-optimg/');
+                        outputImageDirHTML = path.join('/arei-optimg/');
+                    }
+                    else
+                    {
+                        // Local Image. In this case the optimized images are put
+                        // where the original image would be in the final build
+                        originalImagePath = path.join(publicDir, node.url);
+                        outputImageDir = path.dirname(path.join(outDir, node.url));
+                        outputImageDirHTML = path.dirname(node.url);
+                    }
 
                     // the directory the image should be in
                     // and the filename changes with each image
@@ -108,7 +116,7 @@ function remarkEleventyImage()
 
                     const responsiveHTML = createPicture(
                         {
-                            imageDir: path.dirname(node.url),
+                            imageDir: outputImageDirHTML,
                             metadata: stats as {
                                 jpeg?: ImageMetadata[],
                                 webp?: ImageMetadata[],


### PR DESCRIPTION
This removes the limitation I previously set on optimizing external images (the ones you source from other sites).
The optimized external images are placed in a subdirectory of the output folder called `/arei-optimg/`.

[Externally sourced image](https://www.reddit.com/r/iphone/comments/10ux3p4/tried_out_portrait_mode_on_my_new_iphone_14_pro/)
```md
![Test Image](https://preview.redd.it/9aalr8tjajga1.jpg?width=640&crop=smart&auto=webp&v=enabled&s=2498d4313827730e7232c0258720f8ba3b8dc437)
```

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/39662993/216906925-076fadaa-ecaf-49c9-9a27-b7426d46e26f.png">

Resolves #1 