### PR TITLE
Adding support for custom HTML markup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export { remarkEleventyImage } from "./src/astro-remark-images";
+export type { createHTMLProps, MarkupValues } from "./src/types";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-remark-eleventy-image",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-remark-eleventy-image",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-img": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-remark-eleventy-image",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Remark plugin for Astro that automatically optimizes images referenced in markdown files.",
   "author": "ChrisOh431",
   "license": "MIT",

--- a/src/markupUtil.ts
+++ b/src/markupUtil.ts
@@ -1,0 +1,71 @@
+import { MarkupValues } from "./types";
+import path from "path";
+import Image from "@11ty/eleventy-img";
+
+export function defaultMarkup({ src, sources, width, height, alt }: MarkupValues)
+{
+    return `
+        <picture>
+        ${sources}
+        <img
+            src="${src}"
+            width="${width}"
+            height="${height}"
+            alt="${alt}"
+            loading="lazy"
+            decoding="async">
+    </picture>`;
+}
+
+interface CreateHTMLProps
+{
+    imageDir: string,
+    metadata: Image.Metadata,
+    alt: string,
+    sizes: string,
+    isRemote: boolean,
+    mdFilePath: string,
+    customMarkup: ((attributes: MarkupValues) => string) | null,
+}
+export function createHTML({ imageDir, metadata, alt, sizes, isRemote, mdFilePath, customMarkup }: CreateHTMLProps)
+{
+    let baseSource: Image.MetadataEntry[];
+    let highsrc: Image.MetadataEntry;
+
+    // picking the src for the base <img> tag
+    if (metadata.jpeg && metadata.jpeg.length > 0)
+    {
+        baseSource = metadata.jpeg;
+        highsrc = metadata.jpeg[metadata.jpeg.length - 1];
+    }
+    else
+    {
+        // when the image is remote, there's no jpeg, so just use the first format there is
+        baseSource = Object.values(metadata)[0] as Image.MetadataEntry[];
+        highsrc = baseSource[baseSource.length - 1];
+    }
+
+    function generateSrcsets(metadata: Image.Metadata)
+    {
+        function correctSrcset(entry: Image.MetadataEntry)
+        {
+            const filename = path.join(imageDir, path.basename(entry.url)) + ` ${entry.width}w`;
+            return filename;
+        }
+
+        return Object.values(metadata).map(imageFormat =>
+        {
+            return `    <source type="${imageFormat[0].sourceType}" srcset="${imageFormat.map(entry => correctSrcset(entry)).join(", ")}" sizes="${sizes}">\n`;
+        }).join("\n");
+    }
+
+    if (customMarkup)
+    {
+        return customMarkup({ src: path.join(imageDir, path.basename(highsrc.url)), width: highsrc.width, height: highsrc.height, alt: alt, format: baseSource[0].format, sources: generateSrcsets(metadata), isRemote: isRemote, mdFilePath: mdFilePath });
+    }
+    else
+    {
+        return defaultMarkup({ src: path.join(imageDir, path.basename(highsrc.url)), width: highsrc.width, height: highsrc.height, alt: alt, format: baseSource[0].format, sources: generateSrcsets(metadata), isRemote: isRemote, mdFilePath: mdFilePath });
+    }
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,24 @@
+import type Image from "@11ty/eleventy-img";
+
+type MarkupValues = {
+    src: string,
+    width: number,
+    height: number,
+    alt: string,
+    format: string,
+    sources: string,
+    isRemote: boolean,
+    mdFilePath: string,
+};
+
+interface createHTMLProps
+{
+    imageDir: string,
+    metadata: Image.Metadata,
+    alt: string,
+    sizes: string,
+    isRemote: boolean,
+    mdFilePath: string;
+}
+
+export type { MarkupValues, createHTMLProps };


### PR DESCRIPTION
Users can now control how the plugin replaces image nodes with HTML markup in the config. This is helpful for people who want to have a different set of attributes, modify alt text, set custom classes, want a different style of markup for their output, and other use cases.

## Default Markup
```ts
export function defaultMarkup({ src, sources, width, height, alt }: MarkupValues)
{
    return `
        <picture>
        ${sources}
        <img
            src="${src}"
            width="${width}"
            height="${height}"
            alt="${alt}"
            loading="lazy"
            decoding="async">
    </picture>`;
}
```

## Writing your own markup function.
Just create a function that returns a template string with the HTML markup you need. It'll get called in the plugin with the following values passed into the props as an object.

### `astro-config-mjs`
```ts
import { defineConfig } from 'astro/config';
import { remarkEleventyImage } from "astro-remark-eleventy-image";

function customMarkup({ src, width, height, alt, format, sources, isRemote, mdFilePath }) {
    return `
        <picture>
        ${sources}
        <img
            src="${src}"
            width="${width}"
            height="${height}"
            alt="${alt}"
            loading="lazy"
            decoding="async">
    </picture>`;
}

// https://astro.build/config
export default defineConfig({
  markdown: {
    remarkPlugins: [remarkEleventyImage],
    remarkImages: {
      customMarkup: customMarkup
    }
  }
});
```

```ts
type MarkupValues = {
    src: string,
    width: number,
    height: number,
    alt: string,
    format: string,
    sources: string,
    isRemote: boolean,
    mdFilePath: string,
}
```
`src`: The path to the image in your `outDir`. Very recommended to **NOT** modify this and pass it into your \<img\> tag as is. (see the defaultMarkup)

`width`: The width of the optimized image. Keep in mind that this will be the same as the width of the original image.

`height`: The height of the optimized image. Keep in mind that this will be the same as the height of the original image.

`alt`: The alt text associated with the image in Markdown.

`format`: The base format of the optimized image. By default this should be `jpeg` for local images and whatever format the image came with for remote images.

`sources`:  A string containing the proper \<source\> tag markup for the image (the outlined markup).
<img width="718" alt="Screen Shot 2023-02-08 at 1 44 50 PM" src="https://user-images.githubusercontent.com/39662993/217635532-c94146ee-9c35-41e1-9cae-265cd10b93dd.png">

`isRemote`: A Boolean that's true if the image was originally remote (don't worry about this if you don't have `remoteImages` enabled.

`mdFilePath`: The path to the Markdown file referencing this image You could use Node's `path.basename` to get the md file name from this, among other things you might find a use for.

## Custom Markup Examples (`astro.config.mjs`)

### Just an \<img\> node with the optimized image + alt, nothing else
In case you want some simpler markup
```ts
function customMarkup({ src, width, height, alt, format, sources, isRemote, mdFilePath }) {
	return `
	<img
		src="${src}"
		width="${width}"
		height="${height}"
		alt="${alt}"
		loading="lazy"
		decoding="async">
	`;
}
```

### Removing the `width` and `height` attributes from the \<img\> node
@scottaw66's use case
```ts
export function customMarkup({ src, sources, width, height, alt }: MarkupValues)
{
    return `
        <picture>
        ${sources}
        <img
            src="${src}"
            alt="${alt}"
            loading="lazy"
            decoding="async">
    </picture>`;
}
```

### Adding a class
```ts
export function customMarkup({ src, sources, width, height, alt }: MarkupValues)
{
    return `
        <picture class="custom-class">
        ${sources}
        <img
            src="${src}"
            alt="${alt}"
            loading="lazy"
            decoding="async">
    </picture>`;
}
```
