### PR TITLE
fix: avoid "[Error: VipsJpeg: Maximum supported image dimension is 65500 pixels]" error with local images

### DIFF
--- a/src/astro-remark-images.ts
+++ b/src/astro-remark-images.ts
@@ -101,7 +101,11 @@ function remarkEleventyImage()
                 let originalImagePath;
                 let outputImageDir;
                 let outputImageDirHTML;
-                const currentConfig: Image.ImageOptions = {};
+                const currentConfig: Image.ImageOptions = {
+                    // this is so the plugin doesn't crash when trying to optimize remote images
+                    // ([Error: VipsJpeg: Maximum supported image dimension is 65500 pixels])
+                    formats: ['auto']
+                };
 
                 try
                 {
@@ -115,9 +119,6 @@ function remarkEleventyImage()
                         outputImageDir = path.join(outDir, '/arei-optimg/');
                         outputImageDirHTML = path.join('/arei-optimg/');
 
-                        // this is so the plugin doesn't crash when trying to optimize remote images
-                        // ([Error: VipsJpeg: Maximum supported image dimension is 65500 pixels])
-                        currentConfig.formats = ['auto'];
                         currentConfig.filenameFormat = (id, src, width, format) =>
                         {
                             return `${id}-${width}.${format}`;


### PR DESCRIPTION
I also faced the error "[Error: VipsJpeg: Maximum supported image dimension is 65500 pixels]" when building local images.
Therefore, I specified `formats: ['auto']` for local images as well as remote images.