### PR TITLE
Clean up the Types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,10 +2,10 @@ import { AstroIntegration } from "astro";
 import { fileURLToPath } from "node:url";
 import configureRemarkEleventyImagesPlugin from "./src/remark-plugin";
 
-import { createHTML, defaultMarkup } from "./src/markupUtil";
+import { defaultMarkup } from "./src/markupUtil";
 import { RemarkImagesConfig } from "./src/types";
 
-export type { createHTMLProps, MarkupValues } from "./src/types";
+export type { CreateHTMLProps, MarkupValues } from "./src/types";
 
 export default function remarkEleventyImages(options: Partial<RemarkImagesConfig> = {}): AstroIntegration
 {

--- a/src/markupUtil.ts
+++ b/src/markupUtil.ts
@@ -1,17 +1,7 @@
-import { MarkupValues } from "./types";
+import { MarkupValues, CreateHTMLProps } from "./types";
 import path from "path";
 import Image from "@11ty/eleventy-img";
 
-interface CreateHTMLProps
-{
-    imageDir: string,
-    metadata: Image.Metadata,
-    alt: string,
-    sizes: string,
-    isRemote: boolean,
-    mdFilePath: string,
-    markup: ((attributes: MarkupValues) => string),
-}
 export function createHTML({ imageDir, metadata, alt, sizes, isRemote, mdFilePath, markup }: CreateHTMLProps)
 {
     let baseSource: Image.MetadataEntry[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,15 +12,16 @@ type MarkupValues = {
     mdFilePath: string,
 };
 
-interface createHTMLProps
+interface CreateHTMLProps
 {
     imageDir: string,
     metadata: Image.Metadata,
     alt: string,
     sizes: string,
     isRemote: boolean,
-    mdFilePath: string;
-}
+    mdFilePath: string,
+    markup: ((attributes: MarkupValues) => string),
+};
 
 type RemarkImagesConfig = {
     sizes: string,
@@ -30,4 +31,4 @@ type RemarkImagesConfig = {
     altRequired: boolean,
 };
 
-export type { MarkupValues, createHTMLProps, RemarkImagesConfig, ImageOptions };
+export type { MarkupValues, CreateHTMLProps, RemarkImagesConfig, ImageOptions };


### PR DESCRIPTION
Hello! 
Thank you so much for your work on this plugin. Like you, I needed this to exist in order to migrate my website from Gatsby to Astro. I've not used TypeScript that much so let me know if I'm doing something wrong.

Here's what this PR does:
- `markupUtil` was using a local `createHTMLProp` type and not the one that's in `./types`. It's removed now in favour of the other one.
- renamed `createHTMLProp` to `CreateHTMLProp` so the casing is consistent.
- `index.ts` wasn't using `createHTML` 